### PR TITLE
update copyright year to 2024

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'GDCC'
-copyright = '2023, GDCC Members'
+copyright = '2024, GDCC Members'
 author = 'GDCC Members'
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Right now it says 2023:
![Screenshot 2024-09-12 at 3 12 46 PM](https://github.com/user-attachments/assets/607b948e-2a4d-470c-8439-7047f87e6ffc)
