### PR TITLE
Update documentation.md

### DIFF
--- a/source/working-groups/documentation.md
+++ b/source/working-groups/documentation.md
@@ -16,7 +16,7 @@ We welcome anyone to join our meetings!
 
 We meet on the third Friday of the month at 2pm UTC.
 
-Please find us on Google Meet: <https://meet.google.com/ifs-iqjq-vuv>
+Please find us on Google Meet: <https://meet.google.com/yjm-phxw-deb>
 
 You can also find our meetings in the [Dataverse Community Calendar][].
 


### PR DESCRIPTION
I wonder if it'd be better to reference the Dataverse Calendar in here, so people use the Google Meet link that is on the event, so we don't need to update the website whenever there's a link change? 🤔 