### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
I'm setting up dependabot with the same settings we have at https://github.com/IQSS/dataverse/blob/develop/.github/dependabot.yml

Here's a screenshot of the settings:

![Screenshot 2025-02-04 at 12 00 46 PM](https://github.com/user-attachments/assets/140c5129-6c21-494c-909e-3a9a762da9fa)

I noticed we didn't have it set up when poking around this issue:

- #21 