### PR TITLE
Set `--no-root` to fix poetry issue

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -33,7 +33,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # Poetry 2.0 breaks our project: https://github.com/gdcc/www.gdcc.io/issues/21
       - run: pipx install
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,13 +34,13 @@ jobs:
         uses: actions/checkout@v3
 
       # Poetry 2.0 breaks our project: https://github.com/gdcc/www.gdcc.io/issues/21
-      - run: pipx install poetry==1.8.5
+      - run: pipx install
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
           cache: "poetry"
       - run: |
-          poetry install
+          poetry install --no-root
           poetry run task docs-build
 
       - name: Setup Pages


### PR DESCRIPTION
Since Poetry is searching for a source directory that doesn’t exist, it is throwing an error. Running `poetry install --no-root` indicates that there is none to expect, allowing it to run as intended. See this [run](https://github.com/JR-1991/dataversecommunity.global/actions/runs/13206936782) for confirmation.

- Closes #36 